### PR TITLE
Add Two for Tunestr feed to generate TFT music playlist

### DIFF
--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -148,7 +148,7 @@
       "playlistTitle": "Two for Tunestr Music Playlist",
       "playlistDescription": "Every music reference from Two for Tunestr",
       "playlistAuthor": "ChadF",
-      "playlistImageUrl": "",
+      "playlistImageUrl": "https://raw.githubusercontent.com/ChadFarrow/chadf-musicl-playlists/main/docs/TFT-playlist-art.png",
       "enabled": true,
       "lastChecked": null,
       "lastEpisodeGuid": null,

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -139,6 +139,20 @@
       "checkIntervalMinutes": 1440,
       "lastChecked": "2026-02-28T07:27:06.568Z",
       "lastEpisodeGuid": "8c4eec8b-deec-4819-9117-8dd7449575c6"
+    },
+    {
+      "id": "two-for-tunestr-feed",
+      "name": "Two for Tunestr",
+      "rssUrl": "https://feeds.rssblue.com/too-angry-cunts",
+      "playlistId": "TFT-music-playlist",
+      "playlistTitle": "Two for Tunestr Music Playlist",
+      "playlistDescription": "Every music reference from Two for Tunestr",
+      "playlistAuthor": "ChadF",
+      "playlistImageUrl": "",
+      "enabled": true,
+      "lastChecked": null,
+      "lastEpisodeGuid": null,
+      "checkIntervalMinutes": 1440
     }
   ],
   "playlists": [],


### PR DESCRIPTION
Adds new RSS feed entry for the "Two for Tunestr" podcast
(https://feeds.rssblue.com/too-angry-cunts) with playlist ID
TFT-music-playlist and 1440-minute check interval.

https://claude.ai/code/session_01SUpSHR5KAworTBHgAXTtB8